### PR TITLE
Translate web calculator to Spanish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calculadora de Interés Compuesto</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 2rem;
+      background: #f9f9f9;
+    }
+    .container {
+      background: #fff;
+      border-radius: 8px;
+      padding: 2rem;
+      max-width: 400px;
+      margin: auto;
+      box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    }
+    input[type="number"], input[type="range"] {
+      width: 100%;
+      padding: .5rem;
+      margin: .5rem 0 1rem 0;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    button {
+      padding: .5rem 1rem;
+      font-size: 1rem;
+      background: #007bff;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    button:hover {
+      background: #0056b3;
+    }
+
+    #result.fade {
+      opacity: 0;
+      transition: opacity .5s ease-in-out;
+    }
+
+    #result.show {
+      opacity: 1;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Calculadora de Interés Compuesto</h1>
+    <p>Si no ingresas una tasa, asumimos un retorno anual del 9.5%.</p>
+    <label for="monthly">Ahorro mensual ($)</label>
+    <input id="monthly" type="number" min="0" step="0.01" placeholder="Cantidad" />
+    <label for="rate">Tasa anual (%)</label>
+    <input id="rate" type="number" min="0" step="0.01" placeholder="9.5" />
+
+    <label for="monthsRange">Meses de inversión: <span id="monthsValue">12</span></label>
+    <input id="monthsRange" type="range" min="1" max="360" value="12" />
+    <button id="calculate">Calcular</button>
+    <h2 id="result" class="fade"></h2>
+  </div>
+  <script>
+    const monthsRange = document.getElementById('monthsRange');
+    const monthsValue = document.getElementById('monthsValue');
+    monthsRange.addEventListener('input', () => {
+      monthsValue.textContent = monthsRange.value;
+    });
+
+    document.getElementById('calculate').addEventListener('click', function() {
+      const P = parseFloat(document.getElementById('monthly').value);
+      const months = parseInt(monthsRange.value);
+      if (isNaN(P) || isNaN(months) || P <= 0 || months <= 0) {
+        document.getElementById('result').textContent = 'Por favor ingresa números válidos.';
+        document.getElementById('result').classList.add('show');
+        return;
+      }
+      let rateInput = parseFloat(document.getElementById('rate').value);
+      const annualRate = isNaN(rateInput) ? 0.095 : rateInput / 100;
+      const r = annualRate / 12;
+      const n = months;
+      const FV = P * ((Math.pow(1 + r, n) - 1) / r);
+      const formatter = new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'USD' });
+      document.getElementById('result').textContent =
+        'Valor futuro: ' + formatter.format(FV);
+      document.getElementById('result').classList.add('show');
+    });
+  </script>
+</body>
+</html>

--- a/readme.me
+++ b/readme.me
@@ -1,1 +1,7 @@
-// Test
+# Sitio de Interés Compuesto
+
+Abre `index.html` en tu navegador. Ingresa cuánto puedes ahorrar cada mes,
+elige con el control deslizante los meses que mantendrás la inversión y
+opcionalmente proporciona la tasa anual. Si dejas este último campo vacío se
+aplicará el 9.5% por defecto. La aplicación calcula el valor futuro compuesto
+mensualmente y lo muestra formateado como moneda.


### PR DESCRIPTION
## Summary
- translated UI and README to Spanish
- mention the annual 9.5% return in the page
- format the future value as currency using Intl.NumberFormat
- add optional rate input and interactive slider for months

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684b09a80e3c8330a23c297f118746d2